### PR TITLE
Pop!_OS Dark Teal - Update searchbar highlighted field to match Teal color.

### DIFF
--- a/theme-pop-dark--teal/manifest.json
+++ b/theme-pop-dark--teal/manifest.json
@@ -16,6 +16,7 @@
       "popup": "rgb(51, 48, 47)",
       "popup_text": "rgb(246, 246, 246)",
       "tab_loading": "rgb(72, 185, 199)",
+      "toolbar_field_highlight": "rgb(72, 185, 199)",
       "ntp_background": "rgb(51, 48, 47)",
       "ntp_text": "rgb(173, 171, 171)"
     }


### PR DESCRIPTION
First of all, congrats to the theme!

I can't screenshot a searchbar highlighted field 😢, but you can test and check that this JSON property causes the searchbar highlighted field to match the theme color.